### PR TITLE
Feature/discord discourse sync

### DIFF
--- a/packages/bot/src/lib/api/discourse.js
+++ b/packages/bot/src/lib/api/discourse.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const { DISCOURSE_URL, DISCOURSE_API_KEY } = require('../config');
+
+const discourseCategory = 7;
+
+const headers = {
+  'Content-type': 'application/json',
+  'Api-Key': DISCOURSE_API_KEY,
+};
+
+module.exports = ({ request }) => ({
+  async createTopic(id, name) {
+    try {
+      await request({
+        endpoint: `${DISCOURSE_URL}/posts.json`,
+        method: 'POST',
+        headers,
+        data: JSON.stringify({
+          title: name,
+          raw: `This topic has been created from a Discord post ${id}`,
+          category: discourseCategory,
+          external_id: id,
+        }),
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  },
+
+  async getRelatedDiscordTopicOnDiscourse(channelId) {
+    try {
+      const data = await request({
+        endpoint: `${DISCOURSE_URL}/search.json?q=${channelId}`,
+        method: 'GET',
+        headers,
+      });
+      const { posts } = data;
+
+      if (posts?.length > 0) {
+        return posts?.[0];
+      } else {
+        return null;
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  },
+
+  async addPostToDiscordTopic(topic, message, id) {
+    try {
+      await request({
+        endpoint: `${DISCOURSE_URL}/posts.json`,
+        method: 'POST',
+        headers,
+        data: JSON.stringify({
+          raw: message?.content,
+          topic_id: topic?.topic_id,
+          external_id: id,
+          reply_to_post_number: topic?.post_number,
+        }),
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  },
+
+  async updateTopic(topic, message, channelId) {
+    try {
+      await request({
+        endpoint: `${DISCOURSE_URL}/posts/${topic?.id}`,
+        method: 'PUT',
+        headers,
+        data: JSON.stringify({
+          post: {
+            raw: `${message?.content}\n\n<i>This topic has been created from a Discord post (${channelId}) to give it more visibility.\nIt will be on Read-Only mode here.\n<a href="${message?.url}">Join the conversation on Discord</a></i>`,
+            edit_reason: 'Discord bot',
+          },
+        }),
+      });
+
+      await request({
+        endpoint: `${DISCOURSE_URL}/t/${topic?.id}/status.json`,
+        method: 'PUT',
+        headers,
+        data: JSON.stringify({
+          status: 'closed',
+          enabled: 'true',
+        }),
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  },
+});

--- a/packages/bot/src/lib/api/discourse.js
+++ b/packages/bot/src/lib/api/discourse.js
@@ -2,7 +2,20 @@
 
 const { DISCOURSE_URL, DISCOURSE_API_KEY } = require('../config');
 
-const discourseCategory = 7;
+const discourseItems = [
+  {
+    discordChannelId: '1019655562092355594',
+    discourseCategory: 30,
+  },
+  {
+    discordChannelId: '1058454253238235248',
+    discourseCategory: 32,
+  },
+  {
+    discordChannelId: '1058489260531007499',
+    discourseCategory: 31,
+  },
+];
 
 const headers = {
   'Content-type': 'application/json',
@@ -10,7 +23,7 @@ const headers = {
 };
 
 module.exports = ({ request }) => ({
-  async createTopic(id, name) {
+  async createTopic(id, name, parentId) {
     try {
       await request({
         endpoint: `${DISCOURSE_URL}/posts.json`,
@@ -19,12 +32,12 @@ module.exports = ({ request }) => ({
         data: JSON.stringify({
           title: name,
           raw: `This topic has been created from a Discord post ${id}`,
-          category: discourseCategory,
+          category: discourseItems.find((item) => item.discordChannelId === parentId)?.discourseCategory,
           external_id: id,
         }),
       });
     } catch (error) {
-      console.log(error);
+      console.log(error?.repsonse?.data);
     }
   },
 
@@ -43,7 +56,7 @@ module.exports = ({ request }) => ({
         return null;
       }
     } catch (error) {
-      console.log(error);
+      console.log(error?.repsonse?.data);
     }
   },
 
@@ -61,7 +74,7 @@ module.exports = ({ request }) => ({
         }),
       });
     } catch (error) {
-      console.log(error);
+      console.log(error?.repsonse?.data);
     }
   },
 
@@ -89,7 +102,7 @@ module.exports = ({ request }) => ({
         }),
       });
     } catch (error) {
-      console.log(error);
+      console.log(error?.repsonse?.data);
     }
   },
 });

--- a/packages/bot/src/lib/api/discourse.js
+++ b/packages/bot/src/lib/api/discourse.js
@@ -37,7 +37,7 @@ module.exports = ({ request }) => ({
         }),
       });
     } catch (error) {
-      console.log(error?.repsonse?.data);
+      console.log(error?.response?.data);
     }
   },
 
@@ -56,7 +56,7 @@ module.exports = ({ request }) => ({
         return null;
       }
     } catch (error) {
-      console.log(error?.repsonse?.data);
+      console.log(error?.response?.data);
     }
   },
 
@@ -74,7 +74,7 @@ module.exports = ({ request }) => ({
         }),
       });
     } catch (error) {
-      console.log(error?.repsonse?.data);
+      console.log(error?.response?.data);
     }
   },
 
@@ -102,7 +102,7 @@ module.exports = ({ request }) => ({
         }),
       });
     } catch (error) {
-      console.log(error?.repsonse?.data);
+      console.log(error?.response?.data);
     }
   },
 });

--- a/packages/bot/src/lib/api/index.js
+++ b/packages/bot/src/lib/api/index.js
@@ -3,10 +3,12 @@
 const { request } = require('../request');
 const faqs = require('./faqs');
 const docs = require('./docs');
+const discourse = require('./discourse')
 
 const $api = {
   faqs: faqs({ request }),
   docs: docs({ request }),
+  discourse: discourse({ request }),
 };
 
 module.exports = {

--- a/packages/bot/src/lib/config.js
+++ b/packages/bot/src/lib/config.js
@@ -8,4 +8,11 @@ module.exports = {
   API_PREFIX: env('API_PREFIX', 'api'),
   ALGOLIA_API_KEY: env('ALGOLIA_API_KEY'),
   ALGOLIA_APPLICATION_ID: env('ALGOLIA_APPLICATION_ID'),
+  DISCOURSE_URL: env('DISCOURSE_URL', 'https://forum.strapi.io'),
+  DISCOURSE_API_KEY: env('DISCOURSE_API_KEY'),
+  DISCOURSE_FAQ_CHANNELS: env('DISCOURSE_FAQ_CHANNELS', [
+    /* strapi-questions*/ '1019655562092355594',
+    /* frontend-questions*/ '1058454253238235248',
+    /* deployment-questions*/ '1058489260531007499',
+  ]),
 };

--- a/packages/bot/src/lib/request.js
+++ b/packages/bot/src/lib/request.js
@@ -7,7 +7,7 @@ const { BACKEND_URL, API_PREFIX } = require('./config');
 
 const requestInstance = axios.create({
   baseURL: `${BACKEND_URL}/${API_PREFIX}`,
-  timeout: 1000,
+  timeout: 3000,
   headers: {
     Accept: 'application/json',
     'Content-Type': 'application/json',

--- a/packages/bot/src/listeners/message/messageCreate.js
+++ b/packages/bot/src/listeners/message/messageCreate.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { Listener } = require('@sapphire/framework');
+const { DISCOURSE_FAQ_CHANNELS } = require('../../lib/config');
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+class messageCreate extends Listener {
+  constructor(context, options) {
+    super(context, {
+      ...options,
+      event: 'messageCreate',
+    });
+  }
+
+  async run(message) {
+    const { $api } = this.container;
+    const {
+      channelId,
+      id,
+      channel: { parentId },
+    } = message;
+
+    // Proceed only if the channel of the message is a FAQ channel from discord only
+    if (DISCOURSE_FAQ_CHANNELS.includes(parentId)) {
+      // Wait for 2 sec since the threadCreate and messageCreate will occur at the same time.
+      sleep(2000).then(async () => {
+        const topic = await $api.discourse.getRelatedDiscordTopicOnDiscourse(channelId);
+        if (topic === null) return;
+
+        // Prevent the original message to be posted since the threadCreate will handle this already
+        if (id !== channelId) {
+          await $api.discourse.addPostToDiscordTopic(topic, message, id);
+        } else {
+          // Fetch the Discourse orignal post to append this message by channelId which is the id of the first message
+          // If the post hasn't been found, the we can consider a retroactif logic...
+          await $api.discourse.updateTopic(topic, message, channelId);
+        }
+      });
+    }
+  }
+}
+
+module.exports = messageCreate;

--- a/packages/bot/src/listeners/thread/threadCreate.js
+++ b/packages/bot/src/listeners/thread/threadCreate.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { Listener } = require('@sapphire/framework');
+const { DISCOURSE_FAQ_CHANNELS } = require('../../lib/config');
+
+class threadCreate extends Listener {
+  constructor(context, options) {
+    super(context, {
+      ...options,
+      event: 'threadCreate',
+    });
+  }
+
+  async run(thread) {
+    const { $api } = this.container;
+
+    /* A Discord FAQ post `parentId` will always be the `channelId`. */
+    const { id, parentId, name } = thread;
+
+    /* Only create Discourse topic for the channels above */
+    if (DISCOURSE_FAQ_CHANNELS.includes(parentId)) {
+      /* Call Discourse API to create post containing the id of the post in the text for being able to find it later */
+      await $api.discourse.createTopic(id, name);
+    }
+  }
+}
+
+module.exports = threadCreate;

--- a/packages/bot/src/listeners/thread/threadCreate.js
+++ b/packages/bot/src/listeners/thread/threadCreate.js
@@ -20,7 +20,7 @@ class threadCreate extends Listener {
     /* Only create Discourse topic for the channels above */
     if (DISCOURSE_FAQ_CHANNELS.includes(parentId)) {
       /* Call Discourse API to create post containing the id of the post in the text for being able to find it later */
-      await $api.discourse.createTopic(id, name);
+      await $api.discourse.createTopic(id, name, parentId);
     }
   }
 }


### PR DESCRIPTION
This PR establishes a sync between Discord & Discourse.

### How it works

For every new post on Discord on the following existing FAQ channels:
- strapi-questions
- frontend-questions
- deployment-questions
(@derrickmehaffy I saw you created a Discourse category for the `version-migration` channel but it is not a FAQ Discord channel :/)

A new topic will be created on Discord from the commentsBot account under the associated category and be directly closed to prevent double messaging. Then, for every new message on Discord, if it belongs to a thread inside the above categories, it will be appended to the associated topic in Discourse.

## Issues
It seems that with the exact same API permissions, the commentsBot can't lock the topic just after creating it somehow:
```
{
  errors: [ 'You are not permitted to view the requested resource.' ],
  error_type: 'invalid_access'
}
```
event tho, I was able to. 
The only difference between me and him is that I am a moderator, not the bot. 
Can it be the issue @derrickmehaffy?